### PR TITLE
Bugfix for substituing opening quotes with preceding non-breaking space character

### DIFF
--- a/lib/rubypants/core.rb
+++ b/lib/rubypants/core.rb
@@ -270,7 +270,7 @@ class RubyPants < String
     dec_dashes = "#{entity(:en_dash)}|#{entity(:em_dash)}"
 
     # Get most opening single quotes:
-    str.gsub!(/(\s|&nbsp;|--|&[mn]dash;|#{dec_dashes}|&#x201[34];)'(?=\w)/,
+    str.gsub!(/([[:space:]]|&nbsp;|--|&[mn]dash;|#{dec_dashes}|&#x201[34];)'(?=\w)/,
              '\1' + entity(:single_left_quote))
 
     # Single closing quotes:
@@ -284,7 +284,7 @@ class RubyPants < String
               entity(:single_left_quote))
 
     # Get most opening double quotes:
-    str.gsub!(/(\s|&nbsp;|--|&[mn]dash;|#{dec_dashes}|&#x201[34];)"(?=\w)/,
+    str.gsub!(/([[:space:]]|&nbsp;|--|&[mn]dash;|#{dec_dashes}|&#x201[34];)"(?=\w)/,
              '\1' + entity(:double_left_quote))
 
     # Double closing quotes:

--- a/test/rubypants_test.rb
+++ b/test/rubypants_test.rb
@@ -62,6 +62,9 @@ EOF
 
     assert_rp_equal '<b>"</b>', "<b>&#8220;</b>"
     assert_rp_equal 'foo<b>"</b>', "foo<b>&#8221;</b>"
+
+    assert_rp_equal "foo\u00a0\"bar\"", "foo\u00a0&#8220;bar&#8221;"
+    assert_rp_equal "foo\u00a0'bar'", "foo\u00a0&#8216;bar&#8217;"
   end
 
   def test_dashes


### PR DESCRIPTION
A non-breaking space right before a single or double quotes always results in an `entity(:single|double_right_quote)` replacing it.  This bug correctly detects the non-breaking space character and replaces with the appropriate entity.