### PR TITLE
prevent breaks before dashes and ellipses

### DIFF
--- a/lib/rubypants/core.rb
+++ b/lib/rubypants/core.rb
@@ -126,7 +126,7 @@ class RubyPants < String
             t = educate_dashes_inverted t, prevent_breaks   if do_dashes == :inverted
           end
 
-          t = educate_ellipses t  if do_ellipses
+          t = educate_ellipses t, prevent_breaks  if do_ellipses
 
           # Note: backticks need to be processed before quotes.
           if do_backticks
@@ -250,10 +250,10 @@ class RubyPants < String
   # to an ellipsis HTML entity. Also converts the case where there are
   # spaces between the dots.
   #
-  def educate_ellipses(str)
-    str.
-      gsub(RubyPants.n_of(3, '.'), entity(:ellipsis)).
-      gsub(/(?<!\.|\. )\. \. \.(?!\.| \.)/, entity(:ellipsis))
+  def educate_ellipses(str, prevent_breaks=false)
+    str = educate(str, RubyPants.n_of(3, '.'), entity(:ellipsis), prevent_breaks)
+    educate(str, /(?<!\.|\.[[:space:]])\.[[:space:]]\.[[:space:]]\.(?!\.|[[:space:]]\.)/,
+            entity(:ellipsis), prevent_breaks)
   end
 
   # Return the string, with "<tt>``backticks''</tt>"-style single quotes

--- a/lib/rubypants/core.rb
+++ b/lib/rubypants/core.rb
@@ -68,17 +68,18 @@ class RubyPants < String
       do_dashes = :inverted
     elsif @options.include?(-1)
       do_stupefy = true
-    else
-      do_quotes      = @options.include?(:quotes)
-      do_backticks   = @options.include?(:backticks)
-      do_backticks   = :both if @options.include?(:allbackticks)
-      do_dashes      = :normal if @options.include?(:dashes)
-      do_dashes      = :oldschool if @options.include?(:oldschool)
-      do_dashes      = :inverted if @options.include?(:inverted)
-      do_ellipses    = @options.include?(:ellipses)
-      convert_quotes = @options.include?(:convertquotes)
-      do_stupefy     = @options.include?(:stupefy)
     end
+
+    # Explicit flags override numeric flag groups.
+    do_quotes      = true if @options.include?(:quotes)
+    do_backticks   = true if @options.include?(:backticks)
+    do_backticks   = :both if @options.include?(:allbackticks)
+    do_dashes      = :normal if @options.include?(:dashes)
+    do_dashes      = :oldschool if @options.include?(:oldschool)
+    do_dashes      = :inverted if @options.include?(:inverted)
+    do_ellipses    = true if @options.include?(:ellipses)
+    convert_quotes = true if @options.include?(:convertquotes)
+    do_stupefy     = true if @options.include?(:stupefy)
 
     # Parse the HTML
     tokens = tokenize

--- a/lib/rubypants/core.rb
+++ b/lib/rubypants/core.rb
@@ -48,7 +48,7 @@ class RubyPants < String
   # Apply SmartyPants transformations.
   def to_html
     do_quotes = do_backticks = do_dashes = do_ellipses = do_stupify = nil
-    convert_quotes = false
+    convert_quotes = prevent_breaks = nil
 
     if @options.include?(0)
       # Do nothing.
@@ -77,6 +77,7 @@ class RubyPants < String
     do_dashes      = :normal if @options.include?(:dashes)
     do_dashes      = :oldschool if @options.include?(:oldschool)
     do_dashes      = :inverted if @options.include?(:inverted)
+    prevent_breaks = true if @options.include?(:prevent_breaks)
     do_ellipses    = true if @options.include?(:ellipses)
     convert_quotes = true if @options.include?(:convertquotes)
     do_stupefy     = true if @options.include?(:stupefy)
@@ -120,9 +121,9 @@ class RubyPants < String
           t.gsub!(/&quot;/, '"')  if convert_quotes
 
           if do_dashes
-            t = educate_dashes t            if do_dashes == :normal
-            t = educate_dashes_oldschool t  if do_dashes == :oldschool
-            t = educate_dashes_inverted t   if do_dashes == :inverted
+            t = educate_dashes t, prevent_breaks            if do_dashes == :normal
+            t = educate_dashes_oldschool t, prevent_breaks  if do_dashes == :oldschool
+            t = educate_dashes_inverted t, prevent_breaks   if do_dashes == :inverted
           end
 
           t = educate_ellipses t  if do_ellipses
@@ -196,22 +197,38 @@ class RubyPants < String
   DOUBLE_DASH = n_of(2, '-')
   TRIPLE_DASH = n_of(3, '-')
 
-  # The string, with each instance of "<tt>--</tt>" translated to an
-  # em-dash HTML entity.
+  # Return +str+ replacing all +patt+ with +repl+. If +prevent_breaks+ is true,
+  # then replace spaces preceding +patt+ with a non-breaking space, and if there
+  # are no spaces, then insert a word-joiner.
   #
-  def educate_dashes(str)
-    str.
-      gsub(DOUBLE_DASH, entity(:em_dash))
+  def educate(str, patt, repl, prevent_breaks)
+    patt = /(?<spaces>[[:space:]]*)#{patt}/
+    str.gsub(patt) do
+      spaces = if prevent_breaks && $~['spaces'].length > 0
+                 entity(:non_breaking_space) # * $~['spaces'].length
+               elsif prevent_breaks
+                 entity(:word_joiner)
+               else
+                 $~['spaces']
+               end
+      spaces + repl
+    end
   end
 
-  # The string, with each instance of "<tt>--</tt>" translated to an
+  # Return the string, with each instance of "<tt>--</tt>" translated to an
+  # em-dash HTML entity.
+  #
+  def educate_dashes(str, prevent_breaks=false)
+    educate(str, DOUBLE_DASH, entity(:em_dash), prevent_breaks)
+  end
+
+  # Return the string, with each instance of "<tt>--</tt>" translated to an
   # en-dash HTML entity, and each "<tt>---</tt>" translated to an
   # em-dash HTML entity.
   #
-  def educate_dashes_oldschool(str)
-    str.
-      gsub(TRIPLE_DASH, entity(:em_dash)).
-      gsub(DOUBLE_DASH, entity(:en_dash))
+  def educate_dashes_oldschool(str, prevent_breaks=false)
+    str = educate(str, TRIPLE_DASH, entity(:em_dash), prevent_breaks)
+    educate(str, DOUBLE_DASH, entity(:en_dash), prevent_breaks)
   end
 
   # Return the string, with each instance of "<tt>--</tt>" translated
@@ -224,10 +241,9 @@ class RubyPants < String
   # sense that the shortcut should be shorter to type. (Thanks to
   # Aaron Swartz for the idea.)
   #
-  def educate_dashes_inverted(str)
-    str.
-      gsub(TRIPLE_DASH, entity(:en_dash)).
-      gsub(DOUBLE_DASH, entity(:em_dash))
+  def educate_dashes_inverted(str, prevent_breaks=false)
+    str = educate(str, TRIPLE_DASH, entity(:en_dash), prevent_breaks)
+    educate(str, DOUBLE_DASH, entity(:em_dash), prevent_breaks)
   end
 
   # Return the string, with each instance of "<tt>...</tt>" translated
@@ -382,7 +398,9 @@ class RubyPants < String
       :em_dash            => "&#8212;",
       :en_dash            => "&#8211;",
       :ellipsis           => "&#8230;",
-      :html_quote         => "&quot;"
+      :html_quote         => "&quot;",
+      :non_breaking_space => "&nbsp;",
+      :word_joiner        => "&#65279;",
     }
   end
 

--- a/test/rubypants_test.rb
+++ b/test/rubypants_test.rb
@@ -131,20 +131,33 @@ EOF
   end
 
   def test_ellipses
-    assert_rp_equal "foo..bar", 'foo..bar'
-    assert_rp_equal "foo...bar", 'foo&#8230;bar'
-    assert_rp_equal "foo....bar", 'foo....bar'
+    assert_rp_equal "foo..bar", 'foo..bar', [:ellipses]
+    assert_rp_equal "foo...bar", 'foo&#8230;bar', [:ellipses]
+    assert_rp_equal "foo....bar", 'foo....bar', [:ellipses]
+    # and with :prevent_breaks
+    assert_rp_equal "foo..bar", 'foo..bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo...bar", 'foo&#65279;&#8230;bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo....bar", 'foo....bar', [:ellipses, :prevent_breaks]
 
     # dots and spaces
-    assert_rp_equal "foo. . .bar", 'foo&#8230;bar'
-    assert_rp_equal "foo . . . bar", 'foo &#8230; bar'
-    assert_rp_equal "foo. . . .bar", 'foo. . . .bar'
-    assert_rp_equal "foo . . . . bar", 'foo . . . . bar'
+    assert_rp_equal "foo. . .bar", 'foo&#8230;bar', [:ellipses]
+    assert_rp_equal "foo . . . bar", 'foo &#8230; bar', [:ellipses]
+    assert_rp_equal "foo. . . .bar", 'foo. . . .bar', [:ellipses]
+    assert_rp_equal "foo . . . . bar", 'foo . . . . bar', [:ellipses]
+    # and with :prevent_breaks
+    assert_rp_equal "foo. . .bar", 'foo&#65279;&#8230;bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo . . . bar", 'foo&nbsp;&#8230; bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo. . . .bar", 'foo. . . .bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo . . . . bar", 'foo . . . . bar', [:ellipses, :prevent_breaks]
 
-    # Nasty ones
-    assert_rp_equal "foo. . ..bar", 'foo. . ..bar'
-    assert_rp_equal "foo. . ...bar", 'foo. . &#8230;bar'
-    assert_rp_equal "foo. . ....bar", 'foo. . ....bar'
+    # nasty ones
+    assert_rp_equal "foo. . ..bar", 'foo. . ..bar', [:ellipses]
+    assert_rp_equal "foo. . ...bar", 'foo. . &#8230;bar', [:ellipses]
+    assert_rp_equal "foo. . ....bar", 'foo. . ....bar', [:ellipses]
+    # and with :prevent_breaks
+    assert_rp_equal "foo. . ..bar", 'foo. . ..bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo. . ...bar", 'foo. .&nbsp;&#8230;bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo. . ....bar", 'foo. . ....bar', [:ellipses, :prevent_breaks]
   end
 
   def test_backticks

--- a/test/rubypants_test.rb
+++ b/test/rubypants_test.rb
@@ -74,17 +74,47 @@ EOF
     assert_rp_equal "--foo--bar--quux--",
                     '&#8212;foo&#8212;bar&#8212;quux&#8212;', 1
 
+    assert_rp_equal "foo--bar", 'foo&#65279;&#8212;bar', [1, :prevent_breaks]
+    assert_rp_equal "foo --bar", 'foo &#8212;bar', 1
+    assert_rp_equal "foo --bar", 'foo&nbsp;&#8212;bar', [1, :prevent_breaks]
+    assert_rp_equal "foo -- bar", 'foo&nbsp;&#8212; bar', [1, :prevent_breaks]
+    assert_rp_equal "foo  --bar", 'foo&nbsp;&#8212;bar', [1, :prevent_breaks]
+
     assert_rp_equal "foo--bar", 'foo&#8211;bar', 2
     assert_rp_equal "foo---bar", 'foo&#8212;bar', 2
     assert_rp_equal "foo----bar", 'foo----bar', 2
     assert_rp_equal "--foo--bar--quux--",
                     '&#8211;foo&#8211;bar&#8211;quux&#8211;', 2
 
+    assert_rp_equal "foo--bar", 'foo&#65279;&#8211;bar', [2, :prevent_breaks]
+    assert_rp_equal "foo --bar", 'foo &#8211;bar', 2
+    assert_rp_equal "foo --bar", 'foo&nbsp;&#8211;bar', [2, :prevent_breaks]
+    assert_rp_equal "foo -- bar", 'foo&nbsp;&#8211; bar', [2, :prevent_breaks]
+    assert_rp_equal "foo  --bar", 'foo&nbsp;&#8211;bar', [2, :prevent_breaks]
+
+    assert_rp_equal "foo---bar", 'foo&#65279;&#8212;bar', [2, :prevent_breaks]
+    assert_rp_equal "foo ---bar", 'foo &#8212;bar', 2
+    assert_rp_equal "foo ---bar", 'foo&nbsp;&#8212;bar', [2, :prevent_breaks]
+    assert_rp_equal "foo --- bar", 'foo&nbsp;&#8212; bar', [2, :prevent_breaks]
+    assert_rp_equal "foo  ---bar", 'foo&nbsp;&#8212;bar', [2, :prevent_breaks]
+
     assert_rp_equal "foo--bar", 'foo&#8212;bar', 3
     assert_rp_equal "foo---bar", 'foo&#8211;bar', 3
     assert_rp_equal "foo----bar", 'foo----bar', 3
     assert_rp_equal "--foo--bar--quux--",
                     '&#8212;foo&#8212;bar&#8212;quux&#8212;', 3
+
+    assert_rp_equal "foo--bar", 'foo&#65279;&#8212;bar', [3, :prevent_breaks]
+    assert_rp_equal "foo --bar", 'foo &#8212;bar', 3
+    assert_rp_equal "foo --bar", 'foo&nbsp;&#8212;bar', [3, :prevent_breaks]
+    assert_rp_equal "foo -- bar", 'foo&nbsp;&#8212; bar', [3, :prevent_breaks]
+    assert_rp_equal "foo  --bar", 'foo&nbsp;&#8212;bar', [3, :prevent_breaks]
+
+    assert_rp_equal "foo---bar", 'foo&#65279;&#8211;bar', [3, :prevent_breaks]
+    assert_rp_equal "foo ---bar", 'foo &#8211;bar', 3
+    assert_rp_equal "foo ---bar", 'foo&nbsp;&#8211;bar', [3, :prevent_breaks]
+    assert_rp_equal "foo --- bar", 'foo&nbsp;&#8211; bar', [3, :prevent_breaks]
+    assert_rp_equal "foo  ---bar", 'foo&nbsp;&#8211;bar', [3, :prevent_breaks]
   end
 
   def test_html_comments


### PR DESCRIPTION
When `:prevent_breaks` is in `options` then prevent line breaks before replaced dashes and ellipses. This uses [`WORD JOINER`](http://www.fileformat.info/info/unicode/char/2060/index.htm) when there shouldn't be a space, and `&nbsp;` otherwise.