### PR TITLE
Match only triple-dots and space-separated triple-dots as ellipses

### DIFF
--- a/lib/rubypants.rb
+++ b/lib/rubypants.rb
@@ -280,7 +280,7 @@ class RubyPants < String
     educate(str, DOUBLE_DASH, entity(:em_dash), prevent_breaks)
   end
 
-  SPACED_ELLIPSIS_PATTERN = /(?<!\.|\.[[:space:]])\.[[:space:]]\.[[:space:]]\.(?!\.|[[:space:]]\.)/
+  SPACED_ELLIPSIS_PATTERN = /(?<!\.|\.[ ])\.[ ]\.[ ]\.(?!\.|[ ]\.)/
 
   # Return the string, with each instance of "<tt>...</tt>" translated
   # to an ellipsis HTML entity. Also converts the case where there are

--- a/test/rubypants_test.rb
+++ b/test/rubypants_test.rb
@@ -11,6 +11,10 @@ class RubyPantsTest < Minitest::Test
     assert_equal orig, RubyPants.new(str, options, entities).to_html
   end
 
+  def refute_rp_equal(str, orig, options=[2], entities = {})
+    refute_equal orig, RubyPants.new(str, options, entities).to_html
+  end
+
   def assert_verbatim(str)
     assert_rp_equal str, str
   end
@@ -151,6 +155,28 @@ EOF
     assert_rp_equal "foo . . . bar", 'foo&nbsp;&#8230; bar', [:ellipses, :prevent_breaks]
     assert_rp_equal "foo. . . .bar", 'foo. . . .bar', [:ellipses, :prevent_breaks]
     assert_rp_equal "foo . . . . bar", 'foo . . . . bar', [:ellipses, :prevent_breaks]
+
+    # dots and tab-spaces
+    refute_rp_equal "foo.	.	.bar", 'foo&#8230;bar', [:ellipses]
+    refute_rp_equal "foo	.	.	.	bar", 'foo	&#8230;	bar', [:ellipses]
+    assert_rp_equal "foo.	.	.	.bar", 'foo.	.	.	.bar', [:ellipses]
+    assert_rp_equal "foo	.	.	.	.	bar", 'foo	.	.	.	.	bar', [:ellipses]
+    # and with :prevent_breaks
+    refute_rp_equal "foo.	.	.bar", 'foo&#8288;&#8230;bar', [:ellipses, :prevent_breaks]
+    refute_rp_equal "foo	.	.	.	bar", 'foo&nbsp;&#8230;	bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo.	.	.	.bar", 'foo.	.	.	.bar', [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo	.	.	.	.	bar", 'foo	.	.	.	.	bar', [:ellipses, :prevent_breaks]
+
+    # dots and line-breaks
+    refute_rp_equal "foo.\n.\n.bar", 'foo&#8230;bar', [:ellipses]
+    refute_rp_equal "foo\n.\n.\n.\nbar", "foo\n&#8230;\nbar", [:ellipses]
+    assert_rp_equal "foo.\n.\n.\n.bar", "foo.\n.\n.\n.bar", [:ellipses]
+    assert_rp_equal "foo\n.\n.\n.\n.\nbar", "foo\n.\n.\n.\n.\nbar", [:ellipses]
+    # and with :prevent_breaks
+    refute_rp_equal "foo.\n.\n.bar", "foo&#8288;&#8230;bar", [:ellipses, :prevent_breaks]
+    refute_rp_equal "foo\n.\n.\n.\nbar", "foo&nbsp;&#8230;\nbar", [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo.\n.\n.\n.bar", "foo.\n.\n.\n.bar", [:ellipses, :prevent_breaks]
+    assert_rp_equal "foo\n.\n.\n.\n.\nbar", "foo\n.\n.\n.\n.\nbar", [:ellipses, :prevent_breaks]
 
     # nasty ones
     assert_rp_equal "foo. . ..bar", 'foo. . ..bar', [:ellipses]


### PR DESCRIPTION
- Update `SPACED_ELLIPSIS_PATTERN` regex to match only `. . .` (doesn't match `.\t.\t.`)
- added relevant tests