### PR TITLE
Mark mutable string as mutable

### DIFF
--- a/lib/rubypants.rb
+++ b/lib/rubypants.rb
@@ -131,7 +131,7 @@ class RubyPants < String
     in_pre = nil
 
     # Here is the result stored in.
-    result = ""
+    result = +""
 
     # This is a cheat, used to get some context for one-character
     # tokens that consist of just a quote char. What we do is remember


### PR DESCRIPTION
This allows the test suite to pass with RUBYOPT="--enable-frozen-string-literal" This is planned to be the default in the future, so getting this passing now is helpful.